### PR TITLE
OMP Offload Fix

### DIFF
--- a/src/omp/model.cmake
+++ b/src/omp/model.cmake
@@ -155,6 +155,7 @@ macro(setup)
     else ()
 
         # handle the vendor:arch value
+        register_definitions(OMP_TARGET_GPU)
         string(REPLACE ":" ";" OFFLOAD_TUPLE "${OFFLOAD}")
 
         list(LENGTH OFFLOAD_TUPLE LEN)


### PR DESCRIPTION
When using the "Vendor:Arch" format need to the OMP_TARGET_GPU compile definition.