### PR TITLE
fix: make find_package(OpenMP) not required

### DIFF
--- a/src/omp/model.cmake
+++ b/src/omp/model.cmake
@@ -113,8 +113,10 @@ register_flag_optional(OFFLOAD_APPEND_LINK_FLAG
 
 
 macro(setup)
-    find_package(OpenMP REQUIRED)
-    register_link_library(OpenMP::OpenMP_CXX)
+    find_package(OpenMP)
+    if(OpenMP_CXX_FOUND)
+        register_link_library(OpenMP::OpenMP_CXX)
+    endif()
 
     string(TOUPPER ${CMAKE_CXX_COMPILER_ID} COMPILER)
     if(NOT ARCH)


### PR DESCRIPTION
Summit for some reason has a bug where it cannot find OpenMP flgas for clang even though they exist